### PR TITLE
Optimize backend Dockerfile: use JRE instead of JDK to reduce image size

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk AS build
+FROM eclipse-temurin:21-jre AS build
 WORKDIR /app
 
 # Copy the pre-built JAR from the target directory


### PR DESCRIPTION
Lektor rääkis sellest loengus et selles backendi dockerfile-s mis meile anti oli mitte eriti optimaalne failiformaat sees. pmst ma vahetasin ainult 2 tähte ära selles. jdk asemel on nüüd jre 